### PR TITLE
Move autoload function

### DIFF
--- a/autoload/FullHalfWidthTranslator.vim
+++ b/autoload/FullHalfWidthTranslator.vim
@@ -62,3 +62,70 @@ function! FullHalfWidthTranslator#Translate(text, widthType)
 
     return l:resultText
 endfunction
+
+
+" 定义执行转换的函数
+function! FullHalfWidthTranslator#ApplyTransformation(type, widthType)
+    let save_cursor = getpos('.')
+    let t_save = @k
+
+    if a:type == "\<C-V>"
+        " 块选择模式
+        let [line_start, column_start] = getpos("'<")[1:2]
+        let [line_end, column_end] = getpos("'>")[1:2]
+        if column_end < column_start
+            let [column_start, column_end] = [column_end, column_start]
+        endif
+        for line_num in range(line_start, line_end)
+            let line = getline(line_num)
+            let partToTransform = line[column_start - 1: column_end - 1]
+            let transformedPart = FullHalfWidthTranslator#Translate(partToTransform, a:widthType)
+            let newLine = line[:column_start - 2] . transformedPart . line[column_end:]
+            call setline(line_num, newLine)
+        endfor
+    else
+        " 对其他模式的处理
+        if a:type == 'line'
+            normal! '[V']
+        elseif a:type == 'char'
+            normal! `[v`]
+        elseif a:type ==? 'v'
+            normal! gv
+        else
+            normal! '[v']
+        endif
+
+        normal! "ky
+        let selectedText = @k
+        let transformedText = FullHalfWidthTranslator#Translate(selectedText, a:widthType)
+        if transformedText != selectedText
+          call setreg('k', transformedText)
+          normal! gv"kp
+        endif
+    endif
+
+    call setreg('k', t_save)
+    call setpos('.', save_cursor)
+endfunction
+
+" 包装函数
+function! FullHalfWidthTranslator#HalfWidthOperator(type) abort
+  call FullHalfWidthTranslator#ApplyTransformation(a:type, 'halfWidth')
+endfunction
+
+function! FullHalfWidthTranslator#FullWidthOperator(type) abort
+  call FullHalfWidthTranslator#ApplyTransformation(a:type, 'fullWidth')
+endfunction
+
+function! FullHalfWidthTranslator#ToggleWidthOperator(type) abort
+  call FullHalfWidthTranslator#ApplyTransformation(a:type, 'toggleWidth')
+endfunction
+
+function! FullHalfWidthTranslator#ApplyTranslation(widthType) range
+    for lnum in range(a:firstline, a:lastline)
+        let line = getline(lnum)
+        let transformedText = FullHalfWidthTranslator#Translate(line, a:widthType)
+        call setline(lnum, transformedText)
+    endfor
+endfunction
+

--- a/plugin/FullhalfwidthTranslator.vim
+++ b/plugin/FullhalfwidthTranslator.vim
@@ -3,63 +3,6 @@ if exists('g:loaded_FullHalfWidthTranslator.vim_plugin')
 endif
 let g:loaded_FullHalfWidthTranslator_plugifn = 1
 
-" 定义执行转换的函数
-function! FullHalfWidthTranslator#ApplyTransformation(type, widthType)
-    let save_cursor = getpos('.')
-    let t_save = @k
-
-    if a:type == "\<C-V>"
-        " 块选择模式
-        let [line_start, column_start] = getpos("'<")[1:2]
-        let [line_end, column_end] = getpos("'>")[1:2]
-        if column_end < column_start
-            let [column_start, column_end] = [column_end, column_start]
-        endif
-        for line_num in range(line_start, line_end)
-            let line = getline(line_num)
-            let partToTransform = line[column_start - 1: column_end - 1]
-            let transformedPart = FullHalfWidthTranslator#Translate(partToTransform, a:widthType)
-            let newLine = line[:column_start - 2] . transformedPart . line[column_end:]
-            call setline(line_num, newLine)
-        endfor
-    else
-        " 对其他模式的处理
-        if a:type == 'line'
-            normal! '[V']
-        elseif a:type == 'char'
-            normal! `[v`]
-        elseif a:type ==? 'v'
-            normal! gv
-        else
-            normal! '[v']
-        endif
-
-        normal! "ky
-        let selectedText = @k
-        let transformedText = FullHalfWidthTranslator#Translate(selectedText, a:widthType)
-        if transformedText != selectedText
-          call setreg('k', transformedText)
-          normal! gv"kp
-        endif
-    endif
-
-    call setreg('k', t_save)
-    call setpos('.', save_cursor)
-endfunction
-
-" 包装函数
-function! FullHalfWidthTranslator#HalfWidthOperator(type) abort
-  call FullHalfWidthTranslator#ApplyTransformation(a:type, 'halfWidth')
-endfunction
-
-function! FullHalfWidthTranslator#FullWidthOperator(type) abort
-  call FullHalfWidthTranslator#ApplyTransformation(a:type, 'fullWidth')
-endfunction
-
-function! FullHalfWidthTranslator#ToggleWidthOperator(type) abort
-  call FullHalfWidthTranslator#ApplyTransformation(a:type, 'toggleWidth')
-endfunction
-
 " 使用包装函数的映射
 nnoremap <silent> <Plug>(FullWidth2HalfWidth) :set operatorfunc=FullHalfWidthTranslator#HalfWidthOperator<CR>g@
 vnoremap <silent> <Plug>(FullWidth2HalfWidth) :<C-u>call FullHalfWidthTranslator#HalfWidthOperator(visualmode())<CR>
@@ -82,14 +25,6 @@ vnoremap <silent> <Plug>(ToggleFullWidthHalfWidth) :<C-u>call FullHalfWidthTrans
 " Map toggling width
 " nnoremap gwt <Plug>(ToggleFullWidthHalfWidth)
 " vnoremap gwt <Plug>(ToggleFullWidthHalfWidth)
-
-function! FullHalfWidthTranslator#ApplyTranslation(widthType) range
-    for lnum in range(a:firstline, a:lastline)
-        let line = getline(lnum)
-        let transformedText = FullHalfWidthTranslator#Translate(line, a:widthType)
-        call setline(lnum, transformedText)
-    endfor
-endfunction
 
 " 定义命令
 command! -nargs=1 -range TranslateWidthTo :<line1>,<line2>call FullHalfWidthTranslator#ApplyTranslation(<q-args>)


### PR DESCRIPTION
Thanks for your plugins.

I have few vimscript experience but I think these function should be moved into `autoload/`?
```
Failed to source `../b/FullHalfWidthTranslator.vim/plugin/FullhalfwidthTranslator.vim`
../b/nvim/runtime/lua/vim/_editor.lua:441: ../.config/nvim/init.lua..nvim_exec2() called at ../.config/nvim/init.lua:0[1]..../b/FullHalfWidthTranslator.vim/plug
in/FullhalfwidthTranslator.vim, line 48: Vim(function):E746: Function name does not match script file name: FullHalfWidthTranslator#ApplyTransformation
```
